### PR TITLE
Restrict projects to a single project id

### DIFF
--- a/app/_locales/de/messages.json
+++ b/app/_locales/de/messages.json
@@ -23,6 +23,10 @@
     "message": "Codeship API Key",
     "description": "do not translate"
   },
+  "codeship_project_id": {
+    "message": "Codeship Project ID",
+    "description": "do not translate"
+  },
   "copy_api_key": {
     "message": "Kopiere den API Key von deinem Codeship Account.",
     "description": "help in Options panel"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -23,6 +23,10 @@
     "message": "Codeship API Key",
     "description": "do not translate"
   },
+  "codeship_project_id": {
+    "message": "Codeship Project ID",
+    "description": "do not translate"
+  },
   "copy_api_key": {
     "message": "Copy your API Key from your Codeship account",
     "description": "help in Options panel"

--- a/app/js/models/options.js
+++ b/app/js/models/options.js
@@ -1,6 +1,7 @@
 var OptionsModel = Backbone.Model.extend({
   defaults: {
-    api_key: ''
+    api_key: '',
+    project_id: ''
   },
 
   isEmptyApiKey: function() {
@@ -11,7 +12,7 @@ var OptionsModel = Backbone.Model.extend({
   set: function(attrs, options) {
     Backbone.Model.prototype.set.apply(this, arguments);
 
-    if (attrs.api_key && (!options || !options.quiet)) {
+    if ((attrs.api_key || attrs.project_id) && (!options || !options.quiet)) {
       chrome.storage.sync.set(attrs);
     }
   },

--- a/app/js/util/background.js
+++ b/app/js/util/background.js
@@ -53,8 +53,8 @@ var Background = function() {
       })
     },
 
-    fetchApiKeyFromLocalStorage = function(done) {
-      chrome.storage.sync.get('api_key', function(value) {
+    fetchOptionsFromLocalStorage = function(done) {
+      chrome.storage.sync.get(null, function(value) {
         options = value
         done()
       })
@@ -96,7 +96,7 @@ var Background = function() {
       initIntercom()
       initializePolling()
       async.series([
-        fetchApiKeyFromLocalStorage,
+        fetchOptionsFromLocalStorage,
         initializeBuildWatcher,
         fetchProjectsFromCodeship
       ])

--- a/app/js/util/codeship_api.js
+++ b/app/js/util/codeship_api.js
@@ -1,7 +1,8 @@
 var CodeshipApi = (function() {
   var
     API_HOST = "https://codeship.com/api",
-    PROJECT_URL = API_HOST + "/v2/projects.json",
+    ALL_PROJECTS_URL = API_HOST + "/v2/projects.json",
+    SINGLE_PROJECT_URL = API_HOST + "/v1/projects/"
     BUILD_URL = API_HOST + "/v1/builds.json",
 
     fetchAll = function(options, callback) {
@@ -43,9 +44,15 @@ var CodeshipApi = (function() {
     fetchProjects = function(options, callback) {
       if (options && options.api_key != undefined) {
         var params = 'api_key=' + options.api_key
-        $.getJSON(PROJECT_URL, params)
+        $.getJSON(projectUrl(options), params)
           .done( function(response) {
-            projectsCollection = new Projects(response.projects)
+            var response_projects
+            if (options.project_id) {
+              response_projects = [response]
+            } else {
+              response_projects = response.projects
+            }
+            projectsCollection = new Projects(response_projects)
             callback(projectsCollection)
           })
           .fail(function(err) {
@@ -53,6 +60,16 @@ var CodeshipApi = (function() {
             callback(null, {type: 'error', data: err})
           });
       }
+    },
+
+    projectUrl = function(options) {
+      var url
+      if (options.project_id) {
+        url = (SINGLE_PROJECT_URL + options.project_id + ".json")
+      } else {
+        url = ALL_PROJECTS_URL
+      }
+      return url
     }
 
   return {

--- a/app/js/views/options.js
+++ b/app/js/views/options.js
@@ -8,6 +8,7 @@ var OptionsView = Backbone.Marionette.LayoutView.extend({
       msg: {
         save: chrome.i18n.getMessage('save'),
         codeship_api_key: chrome.i18n.getMessage('codeship_api_key'),
+        codeship_project_id: chrome.i18n.getMessage('codeship_project_id'),
         copy_api_key: chrome.i18n.getMessage('copy_api_key'),
         paste_api_key: chrome.i18n.getMessage('paste_api_key'),
       },
@@ -60,6 +61,7 @@ var OptionsView = Backbone.Marionette.LayoutView.extend({
 
     this.listenForApiResult()
     this.model.set({api_key: $('textarea#api_key').val()})
+    this.model.set({project_id: $('textarea#project_id').val()})
     App.intercom.postMessage({type: 'options.set', data: this.model.attributes})
   }
 });

--- a/app/popup.html
+++ b/app/popup.html
@@ -67,6 +67,8 @@
           <label for='api_key' class='control-label'><strong>{{ msg.codeship_api_key }}</strong></label>
           <textarea id='api_key' class='form-control' rows='2' placeholder='{{ msg.paste_api_key }}' autofocus>{{ api_key }}</textarea>
           <span class='help-block'>{{ msg.copy_api_key }}</span>
+          <label for='project_id' class='control-label'><strong>{{ msg.codeship_project_id }}</strong></label>
+          <textarea id='project_id' class='form-control' rows='1'>{{ project_id }}</textarea>
         </div>
         <div class='form-group pull-right'>
           <button id='options_submit' type="submit" class='btn btn-primary btn-xs'>{{ msg.save }}</button>


### PR DESCRIPTION
This change adds a Project ID to the options hash, allowing the user to specify a single project ID.
